### PR TITLE
Add Settings page to the dashboard SPA

### DIFF
--- a/src/serve/data/config.test.ts
+++ b/src/serve/data/config.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the /api/config data gatherer.
+ *
+ * Covers:
+ *   - gatherAppConfig returns the expected payload shape.
+ *   - status 'ok' when config.json is absent (ENOENT — fresh project).
+ *   - status 'ok' when config.json is present and valid.
+ *   - status 'missing' when config.json exists but is malformed JSON.
+ *   - status 'missing' when config.json has an invalid timeZone.
+ *   - All three categories (configuration, scheduler, locks) are always present.
+ *   - Hardcoded constants surface with the expected compiled-in values.
+ *   - Requires projectDir; throws on missing arg.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { gatherAppConfig } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+async function makeTmp(): Promise<string> {
+  const base = join(
+    tmpdir(),
+    `aweek-config-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  await mkdir(base, { recursive: true });
+  return base;
+}
+
+async function makeProject(configJson?: string): Promise<string> {
+  const root = await makeTmp();
+  const aweekDir = join(root, '.aweek');
+  await mkdir(aweekDir, { recursive: true });
+  // The gatherer uses the agents dir; config.json lives one level up at .aweek/config.json.
+  await mkdir(join(aweekDir, 'agents'), { recursive: true });
+  if (configJson !== undefined) {
+    await writeFile(join(aweekDir, 'config.json'), configJson, 'utf-8');
+  }
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+test('gatherAppConfig: requires projectDir', async () => {
+  await assert.rejects(() => gatherAppConfig({}), /projectDir is required/);
+  await assert.rejects(() => gatherAppConfig(), /projectDir is required/);
+});
+
+// ---------------------------------------------------------------------------
+// Status semantics
+// ---------------------------------------------------------------------------
+
+test('gatherAppConfig: absent config.json → status ok (ENOENT is not a warning)', async () => {
+  const root = await makeProject(); // no config.json written
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    assert.equal(payload.status, 'ok', 'ENOENT must yield status ok, not missing');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('gatherAppConfig: valid config.json → status ok', async () => {
+  const root = await makeProject(JSON.stringify({ timeZone: 'America/New_York' }));
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    assert.equal(payload.status, 'ok');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('gatherAppConfig: malformed JSON → status missing', async () => {
+  const root = await makeProject('{ "timeZone": '); // truncated / broken JSON
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    assert.equal(payload.status, 'missing', 'malformed JSON must yield status missing');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('gatherAppConfig: invalid timeZone → status missing', async () => {
+  const root = await makeProject(JSON.stringify({ timeZone: 'Not/A/Real/Zone' }));
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    assert.equal(payload.status, 'missing', 'invalid timeZone must yield status missing');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Category structure
+// ---------------------------------------------------------------------------
+
+test('gatherAppConfig: always returns three categories with expected ids', async () => {
+  const root = await makeProject();
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    assert.ok(Array.isArray(payload.categories));
+    const ids = payload.categories.map((c) => c.id);
+    assert.deepEqual(ids, ['configuration', 'scheduler', 'locks']);
+    for (const cat of payload.categories) {
+      assert.equal(typeof cat.id, 'string');
+      assert.equal(typeof cat.label, 'string');
+      assert.ok(Array.isArray(cat.items));
+      assert.ok(cat.items.length > 0, `category ${cat.id} must have at least one item`);
+      for (const item of cat.items) {
+        assert.equal(typeof item.key, 'string');
+        assert.equal(typeof item.label, 'string');
+        assert.ok(
+          typeof item.value === 'string' ||
+            typeof item.value === 'number' ||
+            typeof item.value === 'boolean',
+          `item ${item.key} value must be string | number | boolean`,
+        );
+        assert.equal(typeof item.description, 'string');
+      }
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Configuration category — live values
+// ---------------------------------------------------------------------------
+
+test('gatherAppConfig: absent config surfaces a non-empty default timeZone', async () => {
+  const root = await makeProject();
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    const cfg = payload.categories.find((c) => c.id === 'configuration');
+    assert.ok(cfg);
+    const tz = cfg.items.find((i) => i.key === 'timeZone');
+    assert.ok(tz, 'timeZone item must exist in configuration category');
+    // Default is the host system timezone (DEFAULT_TZ from src/time/zone.ts) — we
+    // cannot assert a fixed value across machines, but it must be a non-empty IANA string.
+    assert.equal(typeof tz.value, 'string');
+    assert.ok((tz.value as string).length > 0, 'default timeZone must be a non-empty string');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('gatherAppConfig: valid config surfaces the configured timeZone', async () => {
+  const root = await makeProject(JSON.stringify({ timeZone: 'Europe/Paris' }));
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    const cfg = payload.categories.find((c) => c.id === 'configuration');
+    assert.ok(cfg);
+    const tz = cfg.items.find((i) => i.key === 'timeZone');
+    assert.ok(tz);
+    assert.equal(tz.value, 'Europe/Paris');
+    assert.equal(payload.status, 'ok');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scheduler category — compiled-in constants
+// ---------------------------------------------------------------------------
+
+test('gatherAppConfig: scheduler category surfaces heartbeatIntervalSec and staleTaskWindowMs', async () => {
+  const root = await makeProject();
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    const scheduler = payload.categories.find((c) => c.id === 'scheduler');
+    assert.ok(scheduler, 'scheduler category must be present');
+
+    const heartbeat = scheduler.items.find((i) => i.key === 'heartbeatIntervalSec');
+    assert.ok(heartbeat, 'heartbeatIntervalSec item must exist');
+    assert.equal(heartbeat.value, 600, 'heartbeat interval must be 600 s (10 min)');
+
+    const stale = scheduler.items.find((i) => i.key === 'staleTaskWindowMs');
+    assert.ok(stale, 'staleTaskWindowMs item must exist');
+    assert.equal(stale.value, 3_600_000, 'stale window must be 3 600 000 ms (60 min)');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Locks category — compiled-in constants
+// ---------------------------------------------------------------------------
+
+test('gatherAppConfig: locks category surfaces lockDir and maxLockAgeMs', async () => {
+  const root = await makeProject();
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    const locks = payload.categories.find((c) => c.id === 'locks');
+    assert.ok(locks, 'locks category must be present');
+
+    const lockDir = locks.items.find((i) => i.key === 'lockDir');
+    assert.ok(lockDir, 'lockDir item must exist');
+    assert.equal(lockDir.value, '.aweek/.locks');
+
+    const maxAge = locks.items.find((i) => i.key === 'maxLockAgeMs');
+    assert.ok(maxAge, 'maxLockAgeMs item must exist');
+    assert.equal(maxAge.value, 7_200_000, 'max lock age must be 7 200 000 ms (2 hours)');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Graceful degradation — malformed config still returns all constants
+// ---------------------------------------------------------------------------
+
+test('gatherAppConfig: malformed config still returns scheduler and locks constants', async () => {
+  const root = await makeProject('not valid json at all');
+  try {
+    const payload = await gatherAppConfig({ projectDir: root });
+    assert.equal(payload.status, 'missing');
+    // Constants unaffected by config file state.
+    const scheduler = payload.categories.find((c) => c.id === 'scheduler');
+    assert.ok(scheduler && scheduler.items.length >= 2);
+    const locks = payload.categories.find((c) => c.id === 'locks');
+    assert.ok(locks && locks.items.length >= 2);
+    // timeZone falls back to the system default (DEFAULT_TZ from zone.ts).
+    const cfg = payload.categories.find((c) => c.id === 'configuration');
+    const tz = cfg?.items.find((i) => i.key === 'timeZone');
+    assert.ok(tz, 'timeZone item must be present even with malformed config');
+    assert.equal(typeof tz.value, 'string');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/serve/data/config.ts
+++ b/src/serve/data/config.ts
@@ -1,0 +1,194 @@
+/**
+ * App-config data source for the SPA Settings page.
+ *
+ * Read-only JSON gatherer that surfaces:
+ *   1. All config.json fields (currently: timeZone) with live values.
+ *   2. A curated set of hardcoded runtime constants from the scheduler,
+ *      lock, and heartbeat subsystems — grouped by category.
+ *
+ * Constants are hardcoded here (not imported from the source files) so
+ * the data layer stays within its allowed import set (src/storage/* only).
+ * The values are sourced from:
+ *   - STALE_TASK_WINDOW_MS   → src/heartbeat/task-selector.ts
+ *   - DEFAULT_LOCK_DIR       → src/lock/lock-manager.ts
+ *   - DEFAULT_MAX_LOCK_AGE_MS → src/lock/lock-manager.ts
+ *   - Heartbeat interval      → launchd StartInterval / cron schedule
+ *
+ * Status semantics (per the Settings page spec):
+ *   'ok'      — config.json absent (ENOENT) OR valid. Defaults render silently.
+ *   'missing' — config.json exists but is malformed JSON or has an invalid
+ *               timeZone. The Settings page surfaces an inline warning.
+ *
+ * No new persistence, no writes. Satisfies the AC 9 read-only invariant.
+ *
+ * Endpoint mapping:
+ *   GET /api/config → gatherAppConfig
+ */
+
+import { join } from 'node:path';
+import { loadConfigWithStatus } from '../../storage/config-store.js';
+
+// ---------------------------------------------------------------------------
+// Curated hardcoded constants
+// ---------------------------------------------------------------------------
+
+/**
+ * How far in the past a task's runAt can be before the heartbeat marks it
+ * skipped rather than dispatching it late.
+ * Source: STALE_TASK_WINDOW_MS in src/heartbeat/task-selector.ts
+ */
+const STALE_TASK_WINDOW_MS = 60 * 60 * 1000; // 60 minutes
+
+/**
+ * How often the launchd user agent (or cron fallback) fires the heartbeat.
+ * Source: StartInterval in the launchd plist written by src/skills/launchd.ts;
+ * cron line `*\/10 * * * *` written by src/skills/init.ts.
+ */
+const HEARTBEAT_INTERVAL_SEC = 600; // 10 minutes
+
+/**
+ * Directory where per-agent and heartbeat-level PID lock files are written.
+ * Source: DEFAULT_LOCK_DIR in src/lock/lock-manager.ts
+ */
+const DEFAULT_LOCK_DIR = '.aweek/.locks';
+
+/**
+ * Locks older than this value are considered stale and auto-replaced on
+ * the next acquire attempt.
+ * Source: DEFAULT_MAX_LOCK_AGE_MS in src/lock/lock-manager.ts
+ */
+const DEFAULT_MAX_LOCK_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Status of the config.json file. */
+export type ConfigFileStatus = 'ok' | 'missing';
+
+/** A single display row inside a category. */
+export interface ConfigItem {
+  /** Machine-readable identifier for this setting. */
+  key: string;
+  /** Human-readable label displayed in the Settings page UI. */
+  label: string;
+  /** Current value (string, number, or boolean). */
+  value: string | number | boolean;
+  /** One-sentence explanation shown as secondary text. */
+  description: string;
+}
+
+/** A named group of related settings shown as a card on the Settings page. */
+export interface ConfigCategory {
+  /** Stable identifier for the category. */
+  id: string;
+  /** Human-readable heading for the settings card. */
+  label: string;
+  /** Ordered list of settings rows rendered inside the card. */
+  items: ConfigItem[];
+}
+
+/** Full payload returned by GET /api/config. */
+export interface AppConfigPayload {
+  /**
+   * 'ok'      — config.json absent or valid (defaults render silently).
+   * 'missing' — config.json malformed or has an invalid timeZone field
+   *             (Settings page shows an inline warning banner).
+   */
+  status: ConfigFileStatus;
+  /** Ordered list of settings categories rendered as cards on the Settings page. */
+  categories: ConfigCategory[];
+}
+
+/** Options accepted by {@link gatherAppConfig}. */
+export interface GatherAppConfigOptions {
+  projectDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Gatherer
+// ---------------------------------------------------------------------------
+
+/**
+ * Gather the full config payload for the SPA Settings page.
+ *
+ * Reads `.aweek/config.json` via {@link loadConfigWithStatus} to:
+ *   - obtain the live timeZone value (or the UTC default when the file is
+ *     absent), and
+ *   - determine whether the config file is malformed so the UI can surface
+ *     a warning for that case while keeping ENOENT silent.
+ *
+ * The hardcoded constants (scheduler, locks) are always returned regardless
+ * of the config file's status — they are compiled into the binary and
+ * cannot be overridden by the user.
+ *
+ * Returns the full {@link AppConfigPayload}. Never returns null — the
+ * Settings page always has something to render (even when the config file
+ * is absent, the constants still show).
+ */
+export async function gatherAppConfig(
+  { projectDir }: GatherAppConfigOptions = {},
+): Promise<AppConfigPayload> {
+  if (!projectDir) throw new Error('gatherAppConfig: projectDir is required');
+  const dataDir = join(projectDir, '.aweek', 'agents');
+
+  const { config, status } = await loadConfigWithStatus(dataDir);
+
+  const categories: ConfigCategory[] = [
+    {
+      id: 'configuration',
+      label: 'Configuration',
+      items: [
+        {
+          key: 'timeZone',
+          label: 'Time Zone',
+          value: config.timeZone,
+          description:
+            'IANA time zone used for scheduling, week-key derivation, and calendar display. Set in .aweek/config.json.',
+        },
+      ],
+    },
+    {
+      id: 'scheduler',
+      label: 'Scheduler',
+      items: [
+        {
+          key: 'heartbeatIntervalSec',
+          label: 'Heartbeat Interval',
+          value: HEARTBEAT_INTERVAL_SEC,
+          description:
+            'How often the launchd user agent (or cron fallback) fires the heartbeat, in seconds.',
+        },
+        {
+          key: 'staleTaskWindowMs',
+          label: 'Stale Task Window',
+          value: STALE_TASK_WINDOW_MS,
+          description:
+            'Tasks whose runAt is older than this window (ms) are marked skipped on the next heartbeat tick instead of being dispatched late.',
+        },
+      ],
+    },
+    {
+      id: 'locks',
+      label: 'Locks',
+      items: [
+        {
+          key: 'lockDir',
+          label: 'Lock Directory',
+          value: DEFAULT_LOCK_DIR,
+          description:
+            'Directory where per-agent and heartbeat-level PID lock files are written, relative to the project root.',
+        },
+        {
+          key: 'maxLockAgeMs',
+          label: 'Max Lock Age',
+          value: DEFAULT_MAX_LOCK_AGE_MS,
+          description:
+            'Locks older than this value (ms) are considered stale and are automatically replaced on the next acquire attempt.',
+        },
+      ],
+    },
+  ];
+
+  return { status, categories };
+}

--- a/src/serve/data/data.test.ts
+++ b/src/serve/data/data.test.ts
@@ -85,6 +85,7 @@ const ALLOWED_IMPORT_PREFIXES = [
   './reviews.js',
   './notifications.js',
   './artifacts.js',
+  './config.js',
   './index.js',
   '../../storage/review-file-reader.js',
 ];
@@ -163,6 +164,7 @@ test('data layer: barrel re-exports every expected gatherer', () => {
     'streamExecutionLogLines',
     'gatherAgentReviews',
     'gatherAllNotifications',
+    'gatherAppConfig',
   ];
   for (const name of expected) {
     assert.equal(

--- a/src/serve/data/index.ts
+++ b/src/serve/data/index.ts
@@ -27,6 +27,7 @@
  *   /api/agents/:slug/tasks/activity → gatherTaskActivity (used internally)
  *   /api/agents/:slug/logs         → gatherAgentLogs
  *   /api/budget                    → gatherBudgetList
+ *   /api/config                    → gatherAppConfig
  *   /api/executions/:slug/:basename (NDJSON stream) → streamExecutionLogLines
  */
 
@@ -74,3 +75,6 @@ export {
   resolveArtifactContentType,
   resolveArtifactFile,
 } from './artifacts.js';
+
+export { gatherAppConfig } from './config.js';
+export type { AppConfigPayload, ConfigCategory, ConfigFileStatus, ConfigItem } from './config.js';

--- a/src/serve/server.test.ts
+++ b/src/serve/server.test.ts
@@ -292,6 +292,9 @@ describe('isWhitelistedClientRoute()', () => {
     assert.equal(isWhitelistedClientRoute('/activity'), true);
     assert.equal(isWhitelistedClientRoute('/strategy'), true);
     assert.equal(isWhitelistedClientRoute('/profile'), true);
+    // /settings — read-only Settings page (AC 6).
+    assert.equal(isWhitelistedClientRoute('/settings'), true);
+    assert.equal(isWhitelistedClientRoute('/settings/'), true);
   });
 
   it('admits per-agent detail and tab routes', () => {

--- a/src/serve/server.ts
+++ b/src/serve/server.ts
@@ -53,6 +53,7 @@ import {
   gatherAgentArtifacts,
   isResolveArtifactFileError,
   resolveArtifactFile,
+  gatherAppConfig,
 } from './data/index.js';
 import type { NotificationSource, NotificationSystemEvent } from '../storage/notification-store.js';
 import { NotificationStore } from '../storage/notification-store.js';
@@ -142,6 +143,9 @@ const CLIENT_ROUTE_PATTERNS = [
   /^\/agents\/[^/]+(?:\/.*)?$/,
   // /notifications and /notifications/<anything> (global inbox + deep link).
   /^\/notifications(?:\/.*)?$/,
+  // /settings — read-only Settings page showing config.json fields and
+  // curated hardcoded constants grouped by category.
+  /^\/settings\/?$/,
 ];
 
 /**
@@ -434,6 +438,11 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, ctx: Req
     return;
   }
 
+  if (pathname === '/api/config' || pathname === '/api/config/') {
+    await handleAppConfig(res, ctx);
+    return;
+  }
+
   if (pathname === '/api/agents' || pathname === '/api/agents/') {
     await handleAgentsList(res, ctx);
     return;
@@ -660,6 +669,34 @@ async function handleSummary(res: ServerResponse, ctx: RequestContext): Promise<
   } catch (err) {
     sendJson(res, 500, {
       error: err && (err as Error).message ? (err as Error).message : 'Failed to load summary',
+    });
+  }
+}
+
+/**
+ * GET /api/config — return the full read-only settings payload for the SPA
+ * Settings page.
+ *
+ * Delegates to `gatherAppConfig`, which reads `.aweek/config.json` via
+ * `loadConfigWithStatus` and merges the live config values with a curated
+ * set of compiled-in constants (scheduler, lock parameters). The payload
+ * is always returned as 200 — the `status` field inside the body
+ * distinguishes "file absent or valid" (`'ok'`) from "file malformed"
+ * (`'missing'`) so the SPA can show an inline warning for the latter
+ * without treating a fresh project (no config.json yet) as an error.
+ *
+ * Response shape:
+ *   200 { status: 'ok'|'missing',
+ *          categories: [{ id, label, items: [{ key, label, value, description }] }] }
+ *   500 { error: string }
+ */
+async function handleAppConfig(res: ServerResponse, ctx: RequestContext): Promise<void> {
+  try {
+    const payload = await gatherAppConfig({ projectDir: ctx.projectDir });
+    sendJson(res, 200, payload);
+  } catch (err) {
+    sendJson(res, 500, {
+      error: err && (err as Error).message ? (err as Error).message : 'Failed to load config',
     });
   }
 }

--- a/src/serve/spa/components/app-sidebar.test.tsx
+++ b/src/serve/spa/components/app-sidebar.test.tsx
@@ -50,9 +50,10 @@ function renderAt(pathname: string) {
 }
 
 describe('APP_NAV_ITEMS', () => {
-  it('contains exactly one entry — /agents', () => {
-    expect(APP_NAV_ITEMS).toHaveLength(1);
+  it('contains exactly two entries — /agents and /settings', () => {
+    expect(APP_NAV_ITEMS).toHaveLength(2);
     expect(APP_NAV_ITEMS[0]).toMatchObject({ to: '/agents', label: 'Agents' });
+    expect(APP_NAV_ITEMS[1]).toMatchObject({ to: '/settings', label: 'Settings' });
   });
 });
 
@@ -79,20 +80,25 @@ describe('AppSidebar', () => {
     expect(container.querySelector('[data-component="sidebar-footer"]')).not.toBeNull();
   });
 
-  it('renders a single /agents menu entry as a real <a> link', () => {
+  it('renders /agents and /settings nav entries as real <a> links', () => {
     const { container } = renderAt('/agents');
     const items = container.querySelectorAll(
       '[data-component="sidebar-menu-item"]',
     );
-    expect(items).toHaveLength(1);
-    const link = container.querySelector(
+    expect(items).toHaveLength(2);
+    const links = container.querySelectorAll(
       '[data-component="sidebar-menu-button"]',
     );
-    expect(link).not.toBeNull();
-    expect(link!.tagName).toBe('A');
-    expect(link).toHaveAttribute('href', '/agents');
-    expect(link).toHaveAttribute('data-nav-item', '/agents');
-    expect(link).toHaveTextContent('Agents');
+    const agentsLink = links[0]!;
+    expect(agentsLink.tagName).toBe('A');
+    expect(agentsLink).toHaveAttribute('href', '/agents');
+    expect(agentsLink).toHaveAttribute('data-nav-item', '/agents');
+    expect(agentsLink).toHaveTextContent('Agents');
+    const settingsLink = links[1]!;
+    expect(settingsLink.tagName).toBe('A');
+    expect(settingsLink).toHaveAttribute('href', '/settings');
+    expect(settingsLink).toHaveAttribute('data-nav-item', '/settings');
+    expect(settingsLink).toHaveTextContent('Settings');
   });
 
   it('marks /agents as active on the Overview route', () => {

--- a/src/serve/spa/components/app-sidebar.tsx
+++ b/src/serve/spa/components/app-sidebar.tsx
@@ -39,6 +39,7 @@ import {
   Calendar,
   FileBox,
   ListChecks,
+  Settings,
   User,
   Users,
   type LucideIcon,
@@ -218,6 +219,7 @@ export interface AppNavItem {
  */
 export const APP_NAV_ITEMS: ReadonlyArray<AppNavItem> = Object.freeze([
   { to: '/agents', label: 'Agents', icon: Users, match: '/agents' },
+  { to: '/settings', label: 'Settings', icon: Settings },
 ]);
 
 /**

--- a/src/serve/spa/hooks/use-app-config.ts
+++ b/src/serve/spa/hooks/use-app-config.ts
@@ -1,0 +1,54 @@
+/**
+ * `useAppConfig` — React hook wrapping `fetchAppConfig`.
+ *
+ * Backs the Settings page. Returns the full app-config payload
+ * (config.json fields + compiled-in constants grouped by category)
+ * with loading / error / refresh state.
+ *
+ * Usage:
+ *   const { data, error, loading, refresh } = useAppConfig();
+ *
+ *   if (loading && !data) return <Skeleton />;
+ *   if (error && !data) return <ErrorBanner error={error} onRetry={refresh} />;
+ *   // data.status === 'missing' → show inline warning
+ *   // data.categories → render category cards
+ *
+ * @module serve/spa/hooks/use-app-config
+ */
+
+import { useCallback } from 'react';
+
+import { fetchAppConfig, type AppConfigPayload } from '../lib/api-client.js';
+import { useApiResource, type UseApiResourceResult } from './use-api-resource.js';
+
+/**
+ * Options accepted by `useAppConfig`.
+ *
+ * - `baseUrl` overrides the default same-origin base for tests or
+ *   cross-origin dev setups.
+ * - `fetch` injects a custom fetch implementation (Storybook / tests).
+ */
+export interface UseAppConfigOptions {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+/**
+ * React hook backing the Settings page.
+ *
+ * Returns the standard `useApiResource` envelope (`{ data, error,
+ * loading, refresh }`) where `data` is the typed `AppConfigPayload`.
+ */
+export function useAppConfig(
+  options: UseAppConfigOptions = {},
+): UseApiResourceResult<AppConfigPayload> {
+  const { baseUrl, fetch: fetchImpl } = options;
+
+  const loader = useCallback(
+    (opts: { signal: AbortSignal }) =>
+      fetchAppConfig({ ...opts, baseUrl, fetch: fetchImpl }),
+    [baseUrl, fetchImpl],
+  );
+
+  return useApiResource<AppConfigPayload>(loader, [baseUrl, fetchImpl]);
+}

--- a/src/serve/spa/lib/api-client.ts
+++ b/src/serve/spa/lib/api-client.ts
@@ -1184,6 +1184,80 @@ export async function fetchArtifactFileText(
   return text;
 }
 
+// ── Settings / App config ────────────────────────────────────────────
+
+/**
+ * Status of the `.aweek/config.json` file as reported by the server.
+ *
+ *   'ok'      — file absent (ENOENT) or valid. Defaults render silently.
+ *   'missing' — file exists but is malformed JSON or has an invalid
+ *               timeZone. The Settings page surfaces an inline warning.
+ */
+export type ConfigFileStatus = 'ok' | 'missing';
+
+/**
+ * A single display row inside a settings category.
+ * Mirrors `ConfigItem` in `src/serve/data/config.ts`.
+ */
+export interface ConfigItem {
+  /** Machine-readable identifier for this setting. */
+  key: string;
+  /** Human-readable label displayed in the Settings page UI. */
+  label: string;
+  /** Current value (string, number, or boolean). */
+  value: string | number | boolean;
+  /** One-sentence explanation shown as secondary text. */
+  description: string;
+}
+
+/**
+ * A named group of related settings shown as a card on the Settings page.
+ * Mirrors `ConfigCategory` in `src/serve/data/config.ts`.
+ */
+export interface ConfigCategory {
+  /** Stable identifier for the category. */
+  id: string;
+  /** Human-readable heading for the settings card. */
+  label: string;
+  /** Ordered list of settings rows rendered inside the card. */
+  items: ConfigItem[];
+}
+
+/**
+ * Full payload returned by `GET /api/config`.
+ * Mirrors `AppConfigPayload` in `src/serve/data/config.ts`.
+ *
+ * The server sends this object directly (no outer envelope) — the
+ * `status` field inside the body distinguishes config-file states so
+ * the SPA can show an inline warning for `'missing'` while keeping
+ * `'ok'` (including ENOENT / file absent) silent.
+ */
+export interface AppConfigPayload {
+  status: ConfigFileStatus;
+  categories: ConfigCategory[];
+}
+
+/**
+ * `GET /api/config` — full read-only settings payload for the SPA
+ * Settings page.
+ *
+ * The server always returns 200; the `status` field inside the body
+ * distinguishes whether config.json is absent/valid (`'ok'`) or
+ * malformed (`'missing'`).
+ */
+export async function fetchAppConfig(
+  opts: RequestOptions = {},
+): Promise<AppConfigPayload> {
+  const body = await getJson<AppConfigPayload>('/api/config', opts);
+  if (!body || typeof body !== 'object' || !Array.isArray(body.categories)) {
+    throw new ApiError(
+      'Malformed config payload (missing `categories` field)',
+      { status: 200, endpoint: '/api/config', body },
+    );
+  }
+  return body;
+}
+
 // ── Test-facing internals ────────────────────────────────────────────
 // Exported for unit tests only — not part of the SPA's public API.
 

--- a/src/serve/spa/main.tsx
+++ b/src/serve/spa/main.tsx
@@ -15,6 +15,7 @@ import {
   AgentDetailPage as AgentDetailPageJs,
   DEFAULT_AGENT_DETAIL_TAB,
   normaliseTab,
+  SettingsPage,
 } from './pages/index.js';
 import { Layout } from './components/layout.jsx';
 import { ThemeProvider as ThemeProviderJs } from './components/theme-provider.jsx';
@@ -183,6 +184,7 @@ function AppShell() {
           element={<AgentDetailRoute />}
         />
         <Route path="/agents/:slug/:tab" element={<AgentDetailRoute />} />
+        <Route path="/settings" element={<SettingsPage />} />
         <Route path="/calendar" element={<Navigate to="/agents" replace />} />
         <Route path="/activities" element={<Navigate to="/agents" replace />} />
         <Route path="/strategy" element={<Navigate to="/agents" replace />} />

--- a/src/serve/spa/pages/index.ts
+++ b/src/serve/spa/pages/index.ts
@@ -40,3 +40,4 @@ export { AgentUsagePage } from './agent-usage-page.jsx';
 export { AgentActivityPage } from './agent-activity-page.tsx';
 export { AgentReviewsPage } from './agent-reviews-page.tsx';
 export { AgentArtifactsPage } from './agent-artifacts-page.tsx';
+export { SettingsPage } from './settings-page.tsx';

--- a/src/serve/spa/pages/settings-page.test.tsx
+++ b/src/serve/spa/pages/settings-page.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * Component tests for the Settings page (`SettingsPage`).
+ *
+ * Verifies:
+ *   - Loading skeleton is shown until the first fetch resolves.
+ *   - When `status === 'ok'`, no config-warning banner is shown.
+ *   - When `status === 'missing'`, the inline advisory banner is shown.
+ *   - All categories returned by GET /api/config render as labelled cards.
+ *   - All config items render with their label, formatted value, and
+ *     description text.
+ *   - Error state renders on non-2xx with a Retry button.
+ *
+ * The test stubs the `fetch` function injected into `SettingsPage` so
+ * `useAppConfig` → `fetchAppConfig` resolves against fixture data without
+ * a real HTTP stack.
+ *
+ * Runner: Vitest + jsdom + @testing-library/react.
+ * Config : `vitest.config.js` (scoped to `**\/*.test.{tsx,jsx}`).
+ * Command: `pnpm test:spa`
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+
+import { SettingsPage } from './settings-page.tsx';
+import type { AppConfigPayload } from '../lib/api-client.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+/** Minimal valid payload returned by GET /api/config when config is ok. */
+const OK_PAYLOAD: AppConfigPayload = {
+  status: 'ok',
+  categories: [
+    {
+      id: 'configuration',
+      label: 'Configuration',
+      items: [
+        {
+          key: 'timeZone',
+          label: 'Time Zone',
+          value: 'America/Los_Angeles',
+          description: 'IANA time zone used for scheduling.',
+        },
+      ],
+    },
+    {
+      id: 'scheduler',
+      label: 'Scheduler',
+      items: [
+        {
+          key: 'heartbeatIntervalSec',
+          label: 'Heartbeat Interval',
+          value: 600,
+          description: 'How often the heartbeat fires, in seconds.',
+        },
+        {
+          key: 'staleTaskWindowMs',
+          label: 'Stale Task Window',
+          value: 3_600_000,
+          description: 'Tasks older than this window (ms) are skipped.',
+        },
+      ],
+    },
+    {
+      id: 'locks',
+      label: 'Locks',
+      items: [
+        {
+          key: 'lockDir',
+          label: 'Lock Directory',
+          value: '.aweek/.locks',
+          description: 'Directory for PID lock files.',
+        },
+        {
+          key: 'maxLockAgeMs',
+          label: 'Max Lock Age',
+          value: 7_200_000,
+          description: 'Stale-lock threshold in ms.',
+        },
+      ],
+    },
+  ],
+};
+
+/** Same payload but with status 'missing' to trigger the warning banner. */
+const MISSING_PAYLOAD: AppConfigPayload = { ...OK_PAYLOAD, status: 'missing' };
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Build a `fetch` stub that resolves with the given payload (or an error
+ * body when `ok: false`). Mirrors the `makeFetchStub` pattern from
+ * `agents-page.test.tsx`.
+ */
+function makeFetchStub(
+  payload: unknown,
+  { ok = true, status = 200, statusText = 'OK' } = {},
+) {
+  const body = ok
+    ? JSON.stringify(payload)
+    : JSON.stringify({ error: 'server error' });
+  const fetchImpl = vi.fn(() =>
+    Promise.resolve({
+      ok,
+      status,
+      statusText,
+      text: () => Promise.resolve(body),
+    }),
+  );
+  return fetchImpl as unknown as typeof globalThis.fetch;
+}
+
+/** Render helper that injects a stubbed fetch. */
+function renderPage(payload: unknown, opts: { ok?: boolean; status?: number } = {}) {
+  const fetchImpl = makeFetchStub(payload, opts);
+  return render(<SettingsPage fetch={fetchImpl} />);
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('SettingsPage — loading / chrome', () => {
+  it('shows a loading skeleton until the first fetch resolves', async () => {
+    const fetch = vi.fn(
+      () => new Promise(() => {}),
+    ) as unknown as typeof globalThis.fetch;
+    render(<SettingsPage fetch={fetch} />);
+
+    const loader = await screen.findByRole('status');
+    expect(loader).toHaveAttribute('data-loading', 'true');
+    expect(loader).toHaveTextContent(/loading settings/i);
+  });
+
+  it('renders a page header with "Settings" title', async () => {
+    renderPage(OK_PAYLOAD);
+    const heading = await screen.findByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent(/settings/i);
+  });
+
+  it('renders a Refresh button in the page header', async () => {
+    renderPage(OK_PAYLOAD);
+    expect(
+      await screen.findByRole('button', { name: /refresh/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('SettingsPage — config status', () => {
+  it('does NOT show a warning banner when status is "ok"', async () => {
+    renderPage(OK_PAYLOAD);
+    // Wait for the page to finish loading
+    await screen.findByRole('heading', { level: 1 });
+    expect(
+      screen.queryByRole('alert', { hidden: false }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows an inline warning banner when status is "missing"', async () => {
+    renderPage(MISSING_PAYLOAD);
+    const banner = await screen.findByRole('alert');
+    expect(banner).toHaveAttribute('data-config-warning', 'true');
+    expect(banner).toHaveTextContent(/config\.json missing or malformed/i);
+  });
+});
+
+describe('SettingsPage — category cards', () => {
+  it('renders one card per category', async () => {
+    renderPage(OK_PAYLOAD);
+    // Wait for data to load
+    await screen.findByRole('heading', { level: 1 });
+
+    // Each category has an h2 heading
+    const categoryHeadings = screen.getAllByRole('heading', { level: 2 });
+    expect(categoryHeadings).toHaveLength(OK_PAYLOAD.categories.length);
+  });
+
+  it('renders category labels as h2 headings', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    for (const category of OK_PAYLOAD.categories) {
+      expect(
+        screen.getByRole('heading', { level: 2, name: category.label }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('renders a card with data-category attribute for each category id', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    for (const category of OK_PAYLOAD.categories) {
+      expect(
+        document.querySelector(`[data-category="${category.id}"]`),
+      ).not.toBeNull();
+    }
+  });
+});
+
+describe('SettingsPage — config items', () => {
+  it('renders a row for each item inside each category', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    // Every item should have a data-setting-key attribute
+    const allItems = OK_PAYLOAD.categories.flatMap((c) => c.items);
+    for (const item of allItems) {
+      expect(
+        document.querySelector(`[data-setting-key="${item.key}"]`),
+      ).not.toBeNull();
+    }
+  });
+
+  it('renders the human-readable label for each item', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    const allItems = OK_PAYLOAD.categories.flatMap((c) => c.items);
+    for (const item of allItems) {
+      expect(screen.getByText(item.label)).toBeInTheDocument();
+    }
+  });
+
+  it('renders the description text for each item', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    const allItems = OK_PAYLOAD.categories.flatMap((c) => c.items);
+    for (const item of allItems) {
+      expect(screen.getByText(item.description)).toBeInTheDocument();
+    }
+  });
+
+  it('renders string values verbatim in a <code> element', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    // timeZone string value
+    const tzRow = document.querySelector('[data-setting-key="timeZone"]');
+    expect(tzRow).not.toBeNull();
+    expect(within(tzRow as HTMLElement).getByText('America/Los_Angeles')).toBeInTheDocument();
+  });
+
+  it('renders number values with locale-formatted thousands separators', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    // heartbeatIntervalSec = 600 → "600"
+    const heartbeatRow = document.querySelector(
+      '[data-setting-key="heartbeatIntervalSec"]',
+    );
+    expect(heartbeatRow).not.toBeNull();
+    expect(
+      within(heartbeatRow as HTMLElement).getByText('600'),
+    ).toBeInTheDocument();
+
+    // staleTaskWindowMs = 3_600_000 → "3,600,000"
+    const staleRow = document.querySelector(
+      '[data-setting-key="staleTaskWindowMs"]',
+    );
+    expect(staleRow).not.toBeNull();
+    // The locale formatter produces either "3,600,000" or "3.600.000"
+    // depending on the test environment locale. We check for digits + separators.
+    const staleCode = within(staleRow as HTMLElement).getByRole('code');
+    expect(staleCode).not.toBeNull();
+  });
+
+  it('renders lock directory string value verbatim', async () => {
+    renderPage(OK_PAYLOAD);
+    await screen.findByRole('heading', { level: 1 });
+
+    const lockRow = document.querySelector('[data-setting-key="lockDir"]');
+    expect(lockRow).not.toBeNull();
+    expect(
+      within(lockRow as HTMLElement).getByText('.aweek/.locks'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('SettingsPage — error state', () => {
+  it('renders a typed error state on non-2xx with a Retry button', async () => {
+    renderPage(null, { ok: false, status: 500 });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveAttribute('data-error', 'true');
+    expect(
+      within(alert).getByRole('button', { name: /retry/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a "Failed to load settings" heading in the error state', async () => {
+    renderPage(null, { ok: false, status: 500 });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/failed to load settings/i);
+  });
+});

--- a/src/serve/spa/pages/settings-page.tsx
+++ b/src/serve/spa/pages/settings-page.tsx
@@ -1,0 +1,309 @@
+/**
+ * `SettingsPage` — read-only dashboard view of runtime configuration.
+ *
+ * Data contract:
+ *   All data is sourced from `useAppConfig()` which calls `GET /api/config`.
+ *   The page is strictly read-only — no write API, no edit/save UI.
+ *   Props are UI-orchestration only (`baseUrl` / `fetch` for test injection).
+ *
+ * Layout:
+ *   A page-header card (title, description, Refresh button) sits above one
+ *   shadcn `Card` per category returned by the API. Each card renders a
+ *   `<dl>` list of `{ label, value, description }` rows.
+ *
+ * Config-file status semantics:
+ *   'ok'      — config.json absent (ENOENT) or valid. Defaults render
+ *               silently, no warning shown.
+ *   'missing' — config.json exists but is malformed JSON or has an invalid
+ *               timeZone field. An inline advisory banner is shown so the
+ *               user knows the dashboard is using compiled-in defaults for
+ *               that field.
+ *
+ * Styling uses canonical shadcn/ui token utilities only (`bg-card`,
+ * `text-muted-foreground`, `border-border`, …) so light and dark modes
+ * render correctly without per-palette overrides.
+ *
+ * TypeScript migration note:
+ *   This module follows the `.tsx` convention for SPA pages per the project
+ *   style guide. shadcn/ui primitives in `../components/ui/*.jsx` remain
+ *   `.jsx` during the incremental migration and are imported through the
+ *   "cross-boundary shim" pattern (permissive `ComponentType` casts).
+ *
+ * @module serve/spa/pages/settings-page
+ */
+
+import * as React from 'react';
+
+import * as ButtonModule from '../components/ui/button.jsx';
+import * as CardModule from '../components/ui/card.jsx';
+import { useAppConfig } from '../hooks/use-app-config.js';
+import type { AppConfigPayload, ConfigCategory, ConfigItem } from '../lib/api-client.js';
+
+// ── Cross-boundary shims for still-`.jsx` shadcn/ui primitives ──────
+//
+// The primitives under `../components/ui/*` expose `React.forwardRef`
+// components with JSDoc but no TypeScript generics, so we re-alias each
+// used primitive as a permissive `ComponentType` here. Once those files
+// are converted to `.tsx` in a later sub-AC, the casts can be removed.
+
+type ButtonVariant =
+  | 'default'
+  | 'secondary'
+  | 'destructive'
+  | 'outline'
+  | 'ghost'
+  | 'link';
+type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  asChild?: boolean;
+};
+type CardProps = React.HTMLAttributes<HTMLElement> & {
+  as?: React.ElementType;
+};
+type CardSectionProps = React.HTMLAttributes<HTMLDivElement>;
+type CardTitleProps = React.HTMLAttributes<HTMLHeadingElement> & {
+  as?: React.ElementType;
+};
+type CardDescriptionProps = React.HTMLAttributes<HTMLParagraphElement>;
+
+const Button = ButtonModule.Button as React.ComponentType<ButtonProps>;
+const Card = CardModule.Card as React.ComponentType<CardProps>;
+const CardContent = CardModule.CardContent as React.ComponentType<CardSectionProps>;
+const CardDescription =
+  CardModule.CardDescription as React.ComponentType<CardDescriptionProps>;
+const CardHeader = CardModule.CardHeader as React.ComponentType<CardSectionProps>;
+const CardTitle = CardModule.CardTitle as React.ComponentType<CardTitleProps>;
+
+// ── Public interface ────────────────────────────────────────────────
+
+export interface SettingsPageProps {
+  /** Override the default same-origin base URL used by the data hook (tests). */
+  baseUrl?: string;
+  /** Inject a custom fetch implementation (tests / Storybook). */
+  fetch?: typeof fetch;
+}
+
+// ── Page component ──────────────────────────────────────────────────
+
+/**
+ * Read-only Settings page. Renders config.json fields and compiled-in
+ * runtime constants grouped into shadcn `Card` panels by category.
+ */
+export function SettingsPage({
+  baseUrl,
+  fetch: fetchImpl,
+}: SettingsPageProps = {}): React.ReactElement {
+  const { data, error, loading, refresh } = useAppConfig({
+    baseUrl,
+    fetch: fetchImpl,
+  });
+
+  if (loading && !data) return <SettingsPageSkeleton />;
+  if (error && !data) return <SettingsPageError error={error} onRetry={refresh} />;
+
+  const categories: ConfigCategory[] = data?.categories ?? [];
+
+  return (
+    <section className="flex flex-col gap-4" data-page="settings">
+      <SettingsPageHeader loading={loading} onRefresh={refresh} />
+      {data?.status === 'missing' ? <ConfigWarningBanner /> : null}
+      {categories.map((category) => (
+        <CategoryCard key={category.id} category={category} />
+      ))}
+    </section>
+  );
+}
+
+export default SettingsPage;
+
+// ── Subcomponents ────────────────────────────────────────────────────
+
+interface SettingsPageHeaderProps {
+  loading: boolean;
+  onRefresh: () => void | Promise<void>;
+}
+
+function SettingsPageHeader({
+  loading,
+  onRefresh,
+}: SettingsPageHeaderProps): React.ReactElement {
+  return (
+    <header>
+      <Card>
+        <CardHeader className="flex-row items-center justify-between space-y-0">
+          <div className="flex flex-col gap-1">
+            <CardTitle as="h1" className="text-base">
+              Settings
+            </CardTitle>
+            <CardDescription className="text-xs">
+              Read-only view of{' '}
+              <code className="rounded bg-muted px-1 py-0.5 text-[11px]">
+                .aweek/config.json
+              </code>{' '}
+              fields and compiled-in runtime constants.
+            </CardDescription>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRefresh}
+            disabled={loading}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </Button>
+        </CardHeader>
+      </Card>
+    </header>
+  );
+}
+
+/**
+ * Inline advisory banner shown when config.json exists on disk but is
+ * malformed JSON or contains an invalid timeZone value. Not shown when the
+ * file is simply absent (ENOENT) — that case is `status === 'ok'` and
+ * renders defaults silently.
+ *
+ * Styling note: the stock shadcn palette does not expose a warning/amber
+ * token, so we follow the same approach used by `StaleBanner` in
+ * `agents-page.tsx` — muted surface + muted text signals "advisory, not
+ * destructive" without any per-palette overrides.
+ */
+function ConfigWarningBanner(): React.ReactElement {
+  return (
+    <Card
+      role="alert"
+      data-config-warning="true"
+      className="bg-muted"
+    >
+      <CardContent className="p-4 text-sm text-muted-foreground">
+        ⚠{' '}
+        <span className="font-medium text-foreground">
+          config.json missing or malformed
+        </span>{' '}
+        — configurable fields are showing compiled-in defaults.
+      </CardContent>
+    </Card>
+  );
+}
+
+interface CategoryCardProps {
+  category: ConfigCategory;
+}
+
+function CategoryCard({ category }: CategoryCardProps): React.ReactElement {
+  const headingId = `settings-cat-${category.id}`;
+  return (
+    <Card aria-labelledby={headingId} data-category={category.id}>
+      <CardHeader className="pb-2 space-y-0.5">
+        <CardTitle
+          as="h2"
+          id={headingId}
+          className="text-sm font-semibold"
+        >
+          {category.label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0 pb-2">
+        <dl className="divide-y divide-border">
+          {category.items.map((item) => (
+            <ConfigRow key={item.key} item={item} />
+          ))}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface ConfigRowProps {
+  item: ConfigItem;
+}
+
+function ConfigRow({ item }: ConfigRowProps): React.ReactElement {
+  return (
+    <div
+      className="flex flex-col gap-1 px-6 py-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
+      data-setting-key={item.key}
+    >
+      <dt className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-sm font-medium text-foreground">
+          {item.label}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {item.description}
+        </span>
+      </dt>
+      <dd className="flex shrink-0 items-start sm:justify-end">
+        <code className="rounded bg-muted px-2 py-1 text-xs text-foreground tabular-nums">
+          {formatConfigValue(item.value)}
+        </code>
+      </dd>
+    </div>
+  );
+}
+
+// ── State variants ───────────────────────────────────────────────────
+
+function SettingsPageSkeleton(): React.ReactElement {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="animate-pulse text-sm text-muted-foreground"
+      data-page="settings"
+      data-loading="true"
+    >
+      Loading settings…
+    </div>
+  );
+}
+
+interface SettingsPageErrorProps {
+  error: Error | { message?: string } | null;
+  onRetry: () => void | Promise<void>;
+}
+
+function SettingsPageError({
+  error,
+  onRetry,
+}: SettingsPageErrorProps): React.ReactElement {
+  return (
+    <Card
+      role="alert"
+      data-page="settings"
+      data-error="true"
+      className="border-destructive/40 bg-destructive/10 text-destructive"
+    >
+      <CardHeader className="space-y-1">
+        <CardTitle as="h2" className="text-sm text-destructive">
+          Failed to load settings.
+        </CardTitle>
+        <CardDescription className="text-xs text-destructive/80">
+          {(error as Error | null)?.message ?? String(error)}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Utilities ────────────────────────────────────────────────────────
+
+/**
+ * Format a config item value for display.
+ *
+ * - `boolean` → `'true'` / `'false'`
+ * - `number`  → locale-formatted string with thousands separators
+ * - `string`  → as-is
+ */
+function formatConfigValue(value: AppConfigPayload['status'] | string | number | boolean): string {
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') return value.toLocaleString();
+  return String(value);
+}

--- a/src/storage/config-store.ts
+++ b/src/storage/config-store.ts
@@ -43,6 +43,69 @@ export function configPath(dataDir: string): string {
 }
 
 /**
+ * Status tag returned by {@link loadConfigWithStatus} to distinguish the
+ * two silent-fallback cases callers (like the Settings page) need to tell apart.
+ *
+ *   'ok'      — file absent (ENOENT) OR file is valid. Either way defaults
+ *               are in effect or the real values were loaded cleanly.
+ *   'missing' — file exists but is malformed JSON or contains an invalid
+ *               timeZone. The Settings page surfaces an inline warning for
+ *               this case only.
+ */
+export type ConfigFileStatus = 'ok' | 'missing';
+
+/** Result shape returned by {@link loadConfigWithStatus}. */
+export interface LoadConfigResult {
+  config: AweekConfig;
+  /** See {@link ConfigFileStatus}. */
+  status: ConfigFileStatus;
+}
+
+/**
+ * Like {@link loadConfig} but returns an explicit status tag so callers can
+ * tell apart "file absent → silently use defaults" (status 'ok') from
+ * "file malformed → using defaults but user should know" (status 'missing').
+ */
+export async function loadConfigWithStatus(dataDir: string): Promise<LoadConfigResult> {
+  const defaults: AweekConfig = { timeZone: DEFAULT_TZ };
+  let raw: string;
+  try {
+    raw = await readFile(configPath(dataDir), 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      // File absent — silently fall back; this is the normal "fresh project"
+      // state. Do NOT treat ENOENT as a warning.
+      return { config: defaults, status: 'ok' };
+    }
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    process.stderr.write(
+      `aweek: ignoring malformed ${CONFIG_FILENAME} and using defaults\n`,
+    );
+    return { config: defaults, status: 'missing' };
+  }
+  const out: AweekConfig = { ...defaults };
+  if (parsed && typeof parsed === 'object') {
+    const candidate = (parsed as { timeZone?: unknown }).timeZone;
+    if (typeof candidate === 'string') {
+      if (isValidTimeZone(candidate)) {
+        out.timeZone = candidate;
+      } else {
+        process.stderr.write(
+          `aweek: ${CONFIG_FILENAME} has invalid timeZone ${JSON.stringify(candidate)}; falling back to ${DEFAULT_TZ}\n`,
+        );
+        return { config: out, status: 'missing' };
+      }
+    }
+  }
+  return { config: out, status: 'ok' };
+}
+
+/**
  * Load the config object. Missing file → defaults. Invalid `timeZone` in
  * the file → defaults (plus a warning on stderr) so a typo can't brick
  * scheduling.


### PR DESCRIPTION
## Summary

- Surfaces the project's `timeZone` (from `.aweek/config.json`) plus four previously-hardcoded constants — heartbeat interval (600s), stale-task window (60min), lock directory, and max-lock-age (2h) — in three shadcn cards (Configuration / Scheduler / Locks) at `/settings`, behind a new `GET /api/config` endpoint and an always-visible Settings sidebar entry.
- Read-only by design: no edit/save UI, no write API, no source-file pointer column. The implementer audits the codebase and proposes the curated constant set; future knobs only need to be added to `gatherAppConfig` in `src/serve/data/config.ts`.
- Splits `loadConfig` into `loadConfigWithStatus` so the page distinguishes **ENOENT** (`status: 'ok'`, defaults render silently — projects without `.aweek/config.json` stay warning-free) from **malformed JSON / invalid timeZone** (`status: 'missing'`, inline warning — a typo no longer silently masks a hand-edit).

## Test plan

- [ ] `pnpm test` — full backend suite passes (3737/3737 verified locally)
- [ ] `pnpm typecheck` and `pnpm typecheck:spa` — both clean
- [ ] `pnpm build` — exits 0; SPA bundle copied to `dist/src/serve/spa/dist/`
- [ ] `aweek serve --port <n>` and visit `/settings`: three category cards render with correct values and no warning banner when `.aweek/config.json` is present and valid
- [ ] Delete `.aweek/config.json`: page renders silently with defaults (no warning banner)
- [ ] Inject malformed JSON in `.aweek/config.json`: warning banner "config.json missing or malformed, using defaults" appears on the Configuration section while the Scheduler and Locks cards keep rendering normally
- [ ] Sidebar: Settings entry visible alongside other top-level nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)