### PR TITLE
ci(release): switch npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,16 @@ jobs:
             exit 1
           fi
 
+      # Trusted publishing (OIDC): npm mints a short-lived credential from the
+      # `id-token: write` permission above and exchanges it with the registry,
+      # so no long-lived NPM_TOKEN secret is needed. Requires npm >= 11.5.1
+      # (setup-node's Node 22 ships npm 10), so upgrade first. Provenance is
+      # attested automatically for trusted-publisher runs.
+      #
+      # One-time setup on npmjs.com is required for this to work: on the
+      # `aweek` package → Settings → Trusted Publisher, add this GitHub
+      # workflow (repo `runbear-io/aweek`, workflow `release.yml`).
+      - name: Upgrade npm to an OIDC-capable version
+        run: npm install -g npm@latest
+
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

The `release` workflow publishes with a long-lived `NPM_TOKEN` secret that has been **expired/revoked since the 0.1.1 release**. Both the `v0.1.2` (2026-06-23) and `v0.2.0` (2026-06-30) tag runs passed lint + test + build + provenance signing and then failed at the final step:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/aweek - Not found
npm error 404  'aweek@0.2.0' is not in this registry.
```

E404 on `PUT` is npm's standard response for an **unauthorized publish**. npm currently shows only `0.1.0` / `0.1.1` (`latest: 0.1.1`), so `0.1.2` and `0.2.0` never published.

## What

Switch to **npm trusted publishing (OIDC)**:
- npm exchanges the workflow's OIDC token (the existing `id-token: write` permission) for a short-lived registry credential — no `NPM_TOKEN` secret needed, and provenance is attested automatically.
- Removes `NODE_AUTH_TOKEN` from the publish step.
- Upgrades npm to an OIDC-capable version (`>= 11.5.1`; setup-node's Node 22 ships npm 10) before publishing.

## Required one-time setup (npm account owner)

This won't publish until the `aweek` package is configured to trust this workflow:
- npmjs.com → `aweek` package → **Settings → Trusted Publisher** → add GitHub Actions publisher: repo `runbear-io/aweek`, workflow `release.yml`.

## Publishing 0.2.0 after merge

The `v0.2.0` tag points at commit `0cc609f`, which predates this workflow — a tag run uses the workflow file *as of the tagged commit*. So after merging this PR **and** configuring the trusted publisher, re-point the tag at a commit that includes the new workflow (package.json is already `0.2.0`, so the tag-match check still passes):

```bash
git fetch origin
git tag -f v0.2.0 origin/main
git push origin :refs/tags/v0.2.0    # delete remote tag
git push origin v0.2.0               # re-push → triggers release with OIDC
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)